### PR TITLE
Fix SSH pattern to support ssh.github.com hostname

### DIFF
--- a/git-browse.ps1
+++ b/git-browse.ps1
@@ -1,10 +1,18 @@
 Function BrowseTo-GitRepository {
 	[CmdletBinding()]
 	[Alias("origin")]
-	param([string]$remote)
+	param(
+        [string]$remote = $(git config --get remote.origin.url)
+    )
+
+    if (!$remote) {
+        Write-Output "No Git URL found"
+        break
+    }
+
 
 	$matchings = @{
-		"github-ssh"=@("^git@github.com:(?<user>.+)\/(?<git>.*)\.git$", "https://github.com/%user%/%git%")
+		"github-ssh"=@("^git@(ssh\.)?github.com:(?<user>.+)\/(?<git>.*)\.git$", "https://github.com/%user%/%git%")
 		"github-https"=@("^https://github.com/(?<user>.+)/(?<git>.*)$", "https://github.com/%user%/%git%")
 		"azure-devops"=@("https://[^@]+@dev.azure.com/(?<tenant>.+)/(?<project>.+)/_git/(?<git>.*)$", "https://dev.azure.com/%tenant%/%project%/_git/%git%")
 	}


### PR DESCRIPTION
## Changes for git-browse.ps1

- Set default value for `$remote` parameter in **function declaration** to:

    ``` PowerShell
    git config --get remote.origin.url
    ```

- Added validation statement for `$remote` parameter

- Modified `github-ssh` regex pattern to support the **ssh.github.com** hostname. This host supports SSH over port 443. See [Using SSH over the HTTPS port](https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port) for more information.
